### PR TITLE
Fix for when data is string

### DIFF
--- a/src/Servant/Common/Req.hs
+++ b/src/Servant/Common/Req.hs
@@ -218,9 +218,9 @@ jsXhrResponse jsv = [jsu|
 (function () {
    var contentResponse = typeof `jsv.response;
    if( contentResponse == "undefined" ) { // This takes care of the lack of a 'response' field in ie9
-    return JSON.parse(`jsv.responseText);
+    return JSON.parse(JSON.stringify(`jsv.responseText));
    } else if (contentResponse == "string" ) { // IE11 bug
-    return JSON.parse(`jsv.response);
+    return JSON.parse(JSON.stringify(`jsv.response));
    } else {
     return `jsv.response;
    }


### PR DESCRIPTION
@mchaver @msewell17 @smurphy8 

I added `JSON.stringify` before parsing the JSON. 

The reason to `stringify` is because the response itself might be a string literal and parsing a string itself will throw out error.

```javascript
> JSON.parse("Hello")
> VM144:1 Uncaught SyntaxError: Unexpected token H in JSON at position 0
> JSON.parse(JSON.stringify("Hello"))
> "Hello"
```

For Firefox/Chrome, a string `"Hello"` has `responseType` of `json` but IE does not have `json` as value for `responseType`, instead it is just `text`. When the `responseType` is `json`, as far as I know Firefox/Chrome will parse the content to javascript object, thus `obj.response` is already a javascript object. Without `stringify`, `"Hello"` will be parsed again since we are using `typeof` to check for the response type, thus throwing the error. Adding `stringify` might be redundant as we are converting JSON to string to JSON but it should help to avoid the error above.
